### PR TITLE
Utilising AWS Pseudo-parameter types for optional parameters

### DIFF
--- a/templates/ammos-cubs-ait.template.yaml
+++ b/templates/ammos-cubs-ait.template.yaml
@@ -38,7 +38,7 @@ Parameters:
   CognitoDomainName:
     Type: String
   ALBSecurityGroupID:
-    Type: String
+    Type: AWS::EC2::SecurityGroup::Id
   CognitoClientID:
     Type: String
   CognitoClientSecret:

--- a/templates/ammos-cubs-ait.template.yaml
+++ b/templates/ammos-cubs-ait.template.yaml
@@ -31,7 +31,7 @@ Parameters:
     Type: Number
     Default: 604800  # One day
     MinValue: 60
-    MaxValue: 604800 # One day
+    MaxValue: 604800
   IamRoleName:
     Description: Name of the pre-deployed IAM Role to use with the AIT Server
     Type: String

--- a/templates/ammos-cubs-ait.template.yaml
+++ b/templates/ammos-cubs-ait.template.yaml
@@ -31,7 +31,7 @@ Parameters:
     Type: Number
     Default: 604800  # One day
     MinValue: 60
-    MaxValue: 604800
+    MaxValue: 604800 # One day
   IamRoleName:
     Description: Name of the pre-deployed IAM Role to use with the AIT Server
     Type: String

--- a/templates/ammos-cubs-alb.template.yaml
+++ b/templates/ammos-cubs-alb.template.yaml
@@ -18,11 +18,11 @@ Parameters:
     Type: List<AWS::EC2::Subnet::Id>
   AccessSgID:
     Description: (Optional) ID of pre-configured Security Group to control access to ALB
-    Type: String
+    Type: AWS::EC2::SecurityGroup::Id
     Default: ''
   HostedZoneID:
     Description: ID of Route53 Hosted Zone in which to create records for discovery
-    Type: String
+    Type: AWS::Route53::HostedZone::Id
   CognitoUserPoolID:
     Description: User Pool ID of the pre-configured Cognito Environment
     Type: String

--- a/templates/ammos-cubs-alb.template.yaml
+++ b/templates/ammos-cubs-alb.template.yaml
@@ -19,7 +19,7 @@ Parameters:
   AccessSgID:
     Description: (Optional) ID of pre-configured Security Group to control access to ALB
     Type: AWS::EC2::SecurityGroup::Id
-    Default: ''
+    Default: AWS::NoValue
   HostedZoneID:
     Description: ID of Route53 Hosted Zone in which to create records for discovery
     Type: AWS::Route53::HostedZone::Id

--- a/templates/ammos-cubs-editor.template.yaml
+++ b/templates/ammos-cubs-editor.template.yaml
@@ -35,7 +35,7 @@ Parameters:
     Type: String
   ALBSecurityGroupID:
     Description: ID of Pre-configured Security Group attached to the ALB
-    Type: String
+    Type: AWS::EC2::SecurityGroup::Id
   CognitoClientID:
     Description: Client ID from pre-configured cognito environment
     Type: String

--- a/templates/ammos-cubs.main.template.yaml
+++ b/templates/ammos-cubs.main.template.yaml
@@ -213,7 +213,7 @@ Parameters:
     Default: ''
   HostedZoneID:
     Description: (Optional) ID of the Route 53 hosted-zone domain. If you fill in both FQDN and HostedZoneID, this deployment generates an ACM certificate.
-    Type: String
+    Type: AWS::Route53::HostedZone::Id
     MaxLength: 32
     Default: ''
   FQDN:
@@ -234,31 +234,31 @@ Parameters:
     ConstraintDescription: The ProjectName can include numbers, lowercase letters, and hyphens (-).
   VpcId:
     Description: (Optional) If you're deploying into an existing VPC, fill in the VPC ID.
-    Type: String
+    Type: AWS::EC2::VPC::Id
     Default: ''
   PublicSubnet1ID:
     Description: (Optional) If you're deploying into an existing VPC, fill in the ID of the public subnet in Availability Zone 1.
-    Type: String
+    Type: AWS::EC2::Subnet::Id
     Default: ''
   PublicSubnet2ID:
     Description: (Optional) If you're deploying into an existing VPC, fill in the ID of the public subnet in Availability Zone 2.
-    Type: String
+    Type: AWS::EC2::Subnet::Id
     Default: ''
   PrivateSubnet1AID:
     Description: (Optional) If you're deploying into an existing VPC, fill in the ID of the private subnet in Availability Zone 1.
-    Type: String
+    Type: AWS::EC2::Subnet::Id
     Default: ''
   PrivateSubnet2AID:
     Description: (Optional) If you're deploying into an existing VPC, fill in the ID of the private subnet in Availability Zone 2.
-    Type: String
+    Type: AWS::EC2::Subnet::Id
     Default: ''
   PrivateSubnet3AID:
     Description: (Optional) If you're deploying into an existing VPC, fill in the ID of the private subnet in Availability Zone 3.
-    Type: String
+    Type: AWS::EC2::Subnet::Id
     Default: ''
   AccessSgID:
     Description: (Optional) If you're deploying into an existing VPC, fill in the ID of the preconfigured security group to control access to the Application Load Balancer.
-    Type: String
+    Type: AWS::EC2::SecurityGroup::Id
     Default: ''
   DeployIam:
     Description: Allow the QuickStart to deploy the required IAM Roles on your behalf. Otherwise, you will need to pre-deploy

--- a/templates/ammos-cubs.main.template.yaml
+++ b/templates/ammos-cubs.main.template.yaml
@@ -215,7 +215,7 @@ Parameters:
     Description: (Optional) ID of the Route 53 hosted-zone domain. If you fill in both FQDN and HostedZoneID, this deployment generates an ACM certificate.
     Type: AWS::Route53::HostedZone::Id
     MaxLength: 32
-    Default: ''
+    Default: AWS::NoValue
   FQDN:
     Description: URL to use for the project-resources root.
     Type: String
@@ -235,31 +235,31 @@ Parameters:
   VpcId:
     Description: (Optional) If you're deploying into an existing VPC, fill in the VPC ID.
     Type: AWS::EC2::VPC::Id
-    Default: ''
+    Default: AWS::NoValue
   PublicSubnet1ID:
     Description: (Optional) If you're deploying into an existing VPC, fill in the ID of the public subnet in Availability Zone 1.
     Type: AWS::EC2::Subnet::Id
-    Default: ''
+    Default: AWS::NoValue
   PublicSubnet2ID:
     Description: (Optional) If you're deploying into an existing VPC, fill in the ID of the public subnet in Availability Zone 2.
     Type: AWS::EC2::Subnet::Id
-    Default: ''
+    Default: AWS::NoValue
   PrivateSubnet1AID:
     Description: (Optional) If you're deploying into an existing VPC, fill in the ID of the private subnet in Availability Zone 1.
     Type: AWS::EC2::Subnet::Id
-    Default: ''
+    Default: AWS::NoValue
   PrivateSubnet2AID:
     Description: (Optional) If you're deploying into an existing VPC, fill in the ID of the private subnet in Availability Zone 2.
     Type: AWS::EC2::Subnet::Id
-    Default: ''
+    Default: AWS::NoValue
   PrivateSubnet3AID:
     Description: (Optional) If you're deploying into an existing VPC, fill in the ID of the private subnet in Availability Zone 3.
     Type: AWS::EC2::Subnet::Id
-    Default: ''
+    Default: AWS::NoValue
   AccessSgID:
     Description: (Optional) If you're deploying into an existing VPC, fill in the ID of the preconfigured security group to control access to the Application Load Balancer.
     Type: AWS::EC2::SecurityGroup::Id
-    Default: ''
+    Default: AWS::NoValue
   DeployIam:
     Description: Allow the QuickStart to deploy the required IAM Roles on your behalf. Otherwise, you will need to pre-deploy
       these IAM resources before launching the QuickStart; see the Deployment Guide for more details

--- a/templates/ammos-cubs.testing.template.yaml
+++ b/templates/ammos-cubs.testing.template.yaml
@@ -215,7 +215,7 @@ Parameters:
     Description: (Optional) ID of the Route 53 hosted-zone domain. If you fill in both FQDN and HostedZoneID, this deployment generates an ACM certificate.
     Type: AWS::Route53::HostedZone::Id
     MaxLength: 32
-    Default: ''
+    Default: AWS::NoValue
   FQDN:
     Description: URL to use for the project-resources root.
     Type: String
@@ -233,31 +233,31 @@ Parameters:
   VpcId:
     Description: (Optional) If you're deploying into an existing VPC, fill in the VPC ID.
     Type: AWS::EC2::VPC::Id
-    Default: ''
+    Default: AWS::NoValue
   PublicSubnet1ID:
     Description: (Optional) If you're deploying into an existing VPC, fill in the ID of the public subnet in Availability Zone 1.
     Type: AWS::EC2::Subnet::Id
-    Default: ''
+    Default: AWS::NoValue
   PublicSubnet2ID:
     Description: (Optional) If you're deploying into an existing VPC, fill in the ID of the public subnet in Availability Zone 2.
     Type: AWS::EC2::Subnet::Id
-    Default: ''
+    Default: AWS::NoValue
   PrivateSubnet1AID:
     Description: (Optional) If you're deploying into an existing VPC, fill in the ID of the private subnet in Availability Zone 1.
     Type: AWS::EC2::Subnet::Id
-    Default: ''
+    Default: AWS::NoValue
   PrivateSubnet2AID:
     Description: (Optional) If you're deploying into an existing VPC, fill in the ID of the private subnet in Availability Zone 2.
     Type: AWS::EC2::Subnet::Id
-    Default: ''
+    Default: AWS::NoValue
   PrivateSubnet3AID:
     Description: (Optional) If you're deploying into an existing VPC, fill in the ID of the private subnet in Availability Zone 3.
     Type: AWS::EC2::Subnet::Id
-    Default: ''
+    Default: AWS::NoValue
   AccessSgID:
     Description: (Optional) If you're deploying into an existing VPC, fill in the ID of the preconfigured security group to control access to the Application Load Balancer.
     Type: AWS::EC2::SecurityGroup::Id
-    Default: ''
+    Default: AWS::NoValue
   DeployIam:
     Description: Allow the QuickStart to deploy the required IAM Roles on your behalf. Otherwise, you will need to pre-deploy
       these IAM resources before launching the QuickStart; see the Deployment Guide for more details

--- a/templates/ammos-cubs.testing.template.yaml
+++ b/templates/ammos-cubs.testing.template.yaml
@@ -213,7 +213,7 @@ Parameters:
     Default: ''
   HostedZoneID:
     Description: (Optional) ID of the Route 53 hosted-zone domain. If you fill in both FQDN and HostedZoneID, this deployment generates an ACM certificate.
-    Type: String
+    Type: AWS::Route53::HostedZone::Id
     MaxLength: 32
     Default: ''
   FQDN:
@@ -232,31 +232,31 @@ Parameters:
     Type: String
   VpcId:
     Description: (Optional) If you're deploying into an existing VPC, fill in the VPC ID.
-    Type: String
+    Type: AWS::EC2::VPC::Id
     Default: ''
   PublicSubnet1ID:
     Description: (Optional) If you're deploying into an existing VPC, fill in the ID of the public subnet in Availability Zone 1.
-    Type: String
+    Type: AWS::EC2::Subnet::Id
     Default: ''
   PublicSubnet2ID:
     Description: (Optional) If you're deploying into an existing VPC, fill in the ID of the public subnet in Availability Zone 2.
-    Type: String
+    Type: AWS::EC2::Subnet::Id
     Default: ''
   PrivateSubnet1AID:
     Description: (Optional) If you're deploying into an existing VPC, fill in the ID of the private subnet in Availability Zone 1.
-    Type: String
+    Type: AWS::EC2::Subnet::Id
     Default: ''
   PrivateSubnet2AID:
     Description: (Optional) If you're deploying into an existing VPC, fill in the ID of the private subnet in Availability Zone 2.
-    Type: String
+    Type: AWS::EC2::Subnet::Id
     Default: ''
   PrivateSubnet3AID:
     Description: (Optional) If you're deploying into an existing VPC, fill in the ID of the private subnet in Availability Zone 3.
-    Type: String
+    Type: AWS::EC2::Subnet::Id
     Default: ''
   AccessSgID:
     Description: (Optional) If you're deploying into an existing VPC, fill in the ID of the preconfigured security group to control access to the Application Load Balancer.
-    Type: String
+    Type: AWS::EC2::SecurityGroup::Id
     Default: ''
   DeployIam:
     Description: Allow the QuickStart to deploy the required IAM Roles on your behalf. Otherwise, you will need to pre-deploy


### PR DESCRIPTION
PR Opened to resolve the issue discussed [here](https://github.com/ammos-cloud/admin/issues/24)

I have just gone through the `.yaml` files and identified where we can use AWS specific parameter types and updated them from `String` to the specified parameter type. The supported AWS specific parameter types are outlined in the following [AWS Docs](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/parameters-section-structure.html)

For example: `String` -> `AWS::EC2::SecurityGroup::Id`