### PR TITLE
Adding the AIT DSN plugin into the deployment of the AIT-Server

### DIFF
--- a/configs/ait/config/config.yaml
+++ b/configs/ait/config/config.yaml
@@ -29,6 +29,72 @@ default:
 
     emitdefaults:
         filename: emitdefaults.yaml
+    # Adding AIT-DSN Plugin        
+    dsn:
+        sle:
+            initiator_id: LSE
+            # password only matters if we're doing auth and can stay as 'pw'
+            password: pw
+            responder_id: SSC
+            # peer password only matters if we're doing auth and can stay as 'pw'
+            peer_password: pw
+            downlink_frame_type: TMTransFrame
+            heartbeat: 25
+            deadfactor: 5
+            buffer_size: 256000
+            responder_port: 'default'
+            rcf:
+                inst_id: sagr=LSE-SSC.spack=Test.rsl-fg=1.rcf=onlc2
+                hostnames:
+                    - example.hostname.1
+                    - example.hostname.2
+                port: None
+                version: 4
+                spacecraft_id: 250
+                trans_frame_ver_num: 0
+                auth_level: 'none'
+            raf:
+                inst_id: sagr=LSE-SSC.spack=Test.rsl-fg=1.raf=onlc1
+                hostnames:
+                    - example.hostname.1
+                    - example.hostname.2
+                port: None
+                version: 4
+                auth_level: 'none'
+            fcltu:
+                inst_id: None
+                hostnames:
+                    - example.hostname.1
+                    - example.hostname.2
+                port: None
+                version: 4
+                auth_level: 'none'
+            aos:
+                frame_header_error_control_included: false
+                transfer_frame_insert_zone_len: 0
+                operational_control_field_included: false
+                frame_error_control_field_included: false
+                virtual_channels:
+                    1: "b_pdu"
+                    2: "m_pdu"
+                    3: "vca_sdu"
+                    4: "idle"
+
+        cfdp:
+            mib:
+                path: ./mib
+            datasink:
+                outgoing:
+                    path: ../ait/dsn/cfdp/datasink/outgoing
+                incoming:
+                    path: ../ait/dsn/cfdp/datasink/incoming
+                tempfiles:
+                    path: ../ait/dsn/cfdp/datasink/tempfiles
+                pdusink:
+                    path: ../ait/dsn/cfdp/datasink/pdusink
+            max_file_name_length: 64
+            max_entity_id_length: 8
+            max_transaction_id_length: 8
 
     server:
         plugins:

--- a/configs/ait/config/config.yaml
+++ b/configs/ait/config/config.yaml
@@ -29,7 +29,7 @@ default:
 
     emitdefaults:
         filename: emitdefaults.yaml
-    # Adding AIT-DSN Plugin        
+    # Adding AIT-DSN Plugin
     dsn:
         sle:
             initiator_id: LSE

--- a/scripts/ait_bootstrap.sh
+++ b/scripts/ait_bootstrap.sh
@@ -88,6 +88,11 @@ cd $PROJECT_HOME/AIT-GUI/
 git checkout 2.3.1
 pip install .
 
+git clone https://github.com/NASA-AMMOS/AIT-DSN.git $PROJECT_HOME/AIT-DSN
+cd $PROJECT_HOME/AIT-DSN
+git checkout 2.0.0
+pip install .
+
 # Copy necessary apache configs
 cp $SETUP_DIR/httpd_proxy.conf /etc/httpd/conf.d/proxy.conf
 

--- a/scripts/ait_bootstrap.sh
+++ b/scripts/ait_bootstrap.sh
@@ -95,6 +95,9 @@ pip install .
 
 cd $PROJECT_HOME
 
+# Make necessary DSN plugin directories
+mkdir -p $PROJECT_HOME/AIT-Core/ait/dsn/cfdp/datasink/{outgoing,incoming,tempfiles,pdusink}
+
 # Copy necessary apache configs
 cp $SETUP_DIR/httpd_proxy.conf /etc/httpd/conf.d/proxy.conf
 

--- a/scripts/ait_bootstrap.sh
+++ b/scripts/ait_bootstrap.sh
@@ -93,6 +93,8 @@ cd $PROJECT_HOME/AIT-DSN
 git checkout 2.0.0
 pip install .
 
+cd $PROJECT_HOME
+
 # Copy necessary apache configs
 cp $SETUP_DIR/httpd_proxy.conf /etc/httpd/conf.d/proxy.conf
 

--- a/templates/ammos-cubs-ait.template.yaml
+++ b/templates/ammos-cubs-ait.template.yaml
@@ -217,6 +217,11 @@ Resources:
           git checkout 2.3.1
           pip install .
 
+          git clone https://github.com/NASA-AMMOS/AIT-DSN.git $PROJECT_HOME/AIT-DSN
+          cd $PROJECT_HOME/AIT-DSN
+          git checkout 2.0.0
+          pip install .
+          
           # Copy necessary apache configs
           cp $SETUP_DIR/httpd_proxy.conf /etc/httpd/conf.d/proxy.conf
 

--- a/templates/ammos-cubs-ait.template.yaml
+++ b/templates/ammos-cubs-ait.template.yaml
@@ -223,7 +223,10 @@ Resources:
           pip install .
 
           cd $PROJECT_HOME
-          
+
+          # Make necessary DSN plugin directories
+          mkdir -p $PROJECT_HOME/AIT-Core/ait/dsn/cfdp/datasink/{outgoing,incoming,tempfiles,pdusink}
+
           # Copy necessary apache configs
           cp $SETUP_DIR/httpd_proxy.conf /etc/httpd/conf.d/proxy.conf
 

--- a/templates/ammos-cubs-ait.template.yaml
+++ b/templates/ammos-cubs-ait.template.yaml
@@ -221,6 +221,8 @@ Resources:
           cd $PROJECT_HOME/AIT-DSN
           git checkout 2.0.0
           pip install .
+
+          cd $PROJECT_HOME
           
           # Copy necessary apache configs
           cp $SETUP_DIR/httpd_proxy.conf /etc/httpd/conf.d/proxy.conf


### PR DESCRIPTION
Updated the `bootstrap.sh` shell script and the `config` files. 

I've copied the same structure as the installation for the AIT-GUI plugin.

For the config file in `configs/ait/config/config.yaml`, I've used the default `AIT-DSN` parameters based on the configuration recommended by Kabir, available [here](https://github.com/NASA-AMMOS/AIT-DSN/blob/master/config/config.yaml)