### PR TITLE
During testing, longer project names will cause the Aerie LoadBalance…

### DIFF
--- a/templates/aerie-alb.template.yaml
+++ b/templates/aerie-alb.template.yaml
@@ -85,7 +85,7 @@ Resources:
     Properties:
       Type: application
       IpAddressType: ipv4
-      Name: !Sub "${ProjectName}-AerieLoadBalancer"
+      Name: !Sub "${ProjectName}-AerieLB"
       Scheme: internet-facing
       LoadBalancerAttributes:
         - Key: access_logs.s3.enabled

--- a/templates/ast.main.template.yaml
+++ b/templates/ast.main.template.yaml
@@ -237,6 +237,7 @@ Parameters:
     Description: Name of your project. Please use lowercase alphanumeric characters and hypens (-) only.
     Type: String
     AllowedPattern: ^[0-9a-z-]*$
+    MaxLength: 24
     ConstraintDescription: The ProjectName can include numbers, lowercase letters, and hyphens (-).
   VpcId:
     Description: (Optional) If you're deploying into an existing VPC, fill in the VPC ID.


### PR DESCRIPTION
…r name to become longer than 32 characters. This would cause an error during build. This commit (1) decreases the length f the AerieLoad Balancer name and (2) puts a character limit on the project name